### PR TITLE
feat: add shapiro delay visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This project provides a small collection of physics and astronomy utilities.
 - `contracted_length` – compute the Lorentz contracted length for an object moving at relativistic speeds.
 - `light_time_earth_mars` – estimate light travel time between Earth and Mars including the Sun's gravitational delay.
 - `SolarSystemGUI` – interactive Tkinter visualization of the solar system with light-path calculations between planets.
+  The GUI now shows both geometric and Shapiro-delay–corrected light paths and allows
+  magnifying the effect with a slider.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- compute proper light path lengths including solar Shapiro delay
- visualize straight and curved light paths with optional distortion slider
- document Shapiro-aware SolarSystem GUI

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d433ec8083289050e0165b89f68a