### PR TITLE
Fix three player chess app startup

### DIFF
--- a/three_player_chess/__init__.py
+++ b/three_player_chess/__init__.py
@@ -1,5 +1,37 @@
 """Web-based three-player chess game."""
 
-from .app import create_app, generate_qr
+# Importing the Flask application or QR helpers at module import time causes the
+# ``three_player_chess.app`` module to be loaded eagerly.  When the package is
+# executed as ``python -m three_player_chess.app`` this resulted in the module
+# already being present in ``sys.modules`` before its ``__main__`` block ran,
+# triggering a ``RuntimeWarning``.  To avoid this, the public functions are
+# re-exported lazily so that ``three_player_chess.app`` is only imported when
+# they are actually used.
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def _lazy_import() -> ModuleType:
+    """Return the ``three_player_chess.app`` module on demand."""
+
+    from . import app
+
+    return app
+
+
+def create_app():
+    """Proxy to :func:`three_player_chess.app.create_app`."""
+
+    return _lazy_import().create_app()
+
+
+def generate_qr(url: str) -> str:
+    """Proxy to :func:`three_player_chess.app.generate_qr`."""
+
+    return _lazy_import().generate_qr(url)
+
 
 __all__ = ["create_app", "generate_qr"]
+

--- a/three_player_chess/app.py
+++ b/three_player_chess/app.py
@@ -85,3 +85,13 @@ def create_app() -> Flask:
 
 
 __all__ = ["create_app", "generate_qr", "GameState", "state"]
+
+
+def main() -> None:
+    """Run a development server for the three player chess app."""
+
+    create_app().run(debug=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- Lazily re-export helpers in `three_player_chess` to prevent premature module import and runtime warnings
- Add executable entry point to run the Flask development server

## Testing
- `PYTHONPATH=. pytest -q`
- `python3 -m three_player_chess.app & pid=$!; sleep 2; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_68a5ca8d51b08328b908df1919014553